### PR TITLE
Found erronous 24 lines fix them

### DIFF
--- a/day-01/src/main.rs
+++ b/day-01/src/main.rs
@@ -11,27 +11,41 @@ fn read_lines<P>(filename: P) -> io::Result<Vec<String>>
     buffer.lines().collect()
 }
 
-fn find_digits(s: &str) -> Vec<char> {
+fn find_first_and_last_digit(s: &str) -> Vec<char> {
     let map = number_word_map();
     let mut result = Vec::new();
-    let mut current_index = 0;
 
-    while current_index < s.len() {
-        let mut longest_match = None;
+    // Find first valid digit or digit word
+    let mut first_digit_found = false;
+    let mut current_index = 0;
+    while current_index < s.len() && !first_digit_found {
         for end in (current_index + 1)..=s.len() {
             let substring = &s[current_index..end];
-            if map.contains_key(substring) {
-                longest_match = Some(substring);
+            if let Some(&digit) = map.get(substring) {
+                result.push(digit);
+                first_digit_found = true;
+                break;
             }
         }
-
-        if let Some(matching_word) = longest_match {
-            if let Some(&digit) = map.get(matching_word) {
-                result.push(digit);
-            }
-            current_index += matching_word.len();
-        } else {
+        if !first_digit_found {
             current_index += 1;
+        }
+    }
+
+    // Find last valid digit or digit word
+    let mut last_digit_found = false;
+    let mut current_index = s.len();
+    while current_index > 0 && !last_digit_found {
+        for start in (0..current_index).rev() {
+            let substring = &s[start..current_index];
+            if let Some(&digit) = map.get(substring) {
+                result.push(digit);
+                last_digit_found = true;
+                break;
+            }
+        }
+        if !last_digit_found {
+            current_index -= 1;
         }
     }
 
@@ -77,7 +91,7 @@ fn main() {
 
             for cal_val in lines {
                  print!("{};", cal_val);
-                let digits = find_digits(&*cal_val);
+                let digits = find_first_and_last_digit(&*cal_val);
                  print!("Digits found: {:?};", digits);
                 if let Some(number) = concatenate_first_last(digits) {
                     println!(" Number: {}",  number);


### PR DESCRIPTION
These lines were not correct . I rewrote the find digits . I search backwards as well. 
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/patli/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/patli/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\,";
	mso-displayed-thousand-separator:" ";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


Input record | Incorrect numbers where last digit is wrong | Correct numbers where last digit is correct | The Correct value
-- | -- | -- | --
kqxncc74sjttqklx3lxpffbdlthreetwooneightnb | Digits found: ['7', '4', '3', '3', '2', '1'] | Digits found: ['7', '4', '3', '3', '2', '8'] | 78
8kg95ninesixtwonem | Digits found: ['8', '9', '5', '9', '6', '2'] | Digits found: ['8', '9', '5', '9', '6', '1'] | 81
sevennfkfvxsqr7twotwonedb | Digits found: ['7', '7', '2', '2'] | Digits found: ['7', '7', '2', '1'] | 71
9xnbmgqgvrtwonevs | Digits found: ['9', '2'] | Digits found: ['9', '1'] | 91
twollzsslxc37sixoneightp | Digits found: ['2', '3', '7', '6', '1'] | Digits found: ['2', '3', '7', '6', '8'] | 28
eight8eightwoh | Digits found: ['8', '8', '8'] | Digits found: ['8', '8', '2'] | 82
51fivepbxrzkdzjhsixoneightmt | Digits found: ['5', '1', '5', '6', '1'] | Digits found: ['5', '1', '5', '6', '8'] | 58
712onekndmfive6ntrmsk8eightwop | Digits found: ['7', '1', '2', '1', '5', '6', '8', '8'] | Digits found: ['7', '1', '2', '1', '5', '6', '8', '2'] | 72
28four78tmrkfndeighteightwonq | Digits found: ['2', '8', '4', '7', '8', '8', '8'] | Digits found: ['2', '8', '4', '7', '8', '8', '2'] | 22
8sixthreetwonez | Digits found: ['8', '6', '3', '2'] | Digits found: ['8', '6', '3', '1'] | 81
onetwo4eight31loneighttc | Digits found: ['1', '2', '4', '8', '3', '1', '1'] | Digits found: ['1', '2', '4', '8', '3', '1', '8'] | 18
92six1threeeightwot | Digits found: ['9', '2', '6', '1', '3', '8'] | Digits found: ['9', '2', '6', '1', '3', '2'] | 92
3qzjrffxdthreeoneightbc | Digits found: ['3', '3', '1'] | Digits found: ['3', '3', '8'] | 38
25kljltwoneggk | Digits found: ['2', '5', '2'] | Digits found: ['2', '5', '1'] | 21
1oneqphkrtwojczlpmcjseven38oneightgm | Digits found: ['1', '1', '2', '7', '3', '8', '1'] | Digits found: ['1', '1', '2', '7', '3', '8', '8'] | 18
four4one7cztqmheightwompd | Digits found: ['4', '4', '1', '7', '8'] | Digits found: ['4', '4', '1', '7', '2'] | 42
eightdndsvdcqneight9twonenf | Digits found: ['8', '8', '9', '2'] | Digits found: ['8', '8', '9', '1'] | 81
7sevenfivegpllcnbvf3khjsqtwoner | Digits found: ['7', '7', '5', '3', '2'] | Digits found: ['7', '7', '5', '3', '1'] | 71
3two9six9sixfiveoneightf | Digits found: ['3', '2', '9', '6', '9', '6', '5', '1'] | Digits found: ['3', '2', '9', '6', '9', '6', '5', '8'] | 38
nine1eightwox | Digits found: ['9', '1', '8'] | Digits found: ['9', '1', '2'] | 92
threekdfzqhqeight54four7twonep | Digits found: ['3', '8', '5', '4', '4', '7', '2'] | Digits found: ['3', '8', '5', '4', '4', '7', '1'] | 31
three4eightwol | Digits found: ['3', '4', '8'] | Digits found: ['3', '4', '2'] | 32
56fourcsfpfnntpkfcsqkkp6oneightlsv | Digits found: ['5', '6', '4', '6', '1'] | Digits found: ['5', '6', '4', '6', '8'] | 58
ggdone3nbmsthreefourninefiveoneightpr | Digits found: ['1', '3', '3', '4', '9', '5', '1'] | Digits found: ['1', '3', '3', '4', '9', '5', '8'] | 18



</body>

</html>
